### PR TITLE
Orderbook loading fix and message

### DIFF
--- a/lib/screens/markets/order_book_page.dart
+++ b/lib/screens/markets/order_book_page.dart
@@ -283,7 +283,7 @@ class _OrderBookPageState extends State<OrderBookPage> {
           padding: const EdgeInsets.all(16.0),
           child: Text(
               'The order book is currently unavailable for the selected pair.',
-              style: TextStyle(fontSize: 20)),
+              style: Theme.of(context).textTheme.headline6),
         );
       }
     }

--- a/lib/screens/markets/order_book_page.dart
+++ b/lib/screens/markets/order_book_page.dart
@@ -274,7 +274,18 @@ class _OrderBookPageState extends State<OrderBookPage> {
     } catch (_) {}
 
     if (_pairOrderBook == null) {
-      return const Center(heightFactor: 10, child: CircularProgressIndicator());
+      String orderbookError = _orderBookProvider.getOrderbookError();
+      if (orderbookError == null) {
+        return const Center(
+            heightFactor: 10, child: CircularProgressIndicator());
+      } else {
+        return Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Text(
+              'The order book is currently unavailable for the selected pair.',
+              style: TextStyle(fontSize: 20)),
+        );
+      }
     }
 
     final List<Ask> _sortedAsks =

--- a/lib/services/mm.dart
+++ b/lib/services/mm.dart
@@ -445,7 +445,7 @@ class ApiProvider {
     GetOrderbook body,
   ) async {
     try {
-      await _assertUserpass(client, body).then<dynamic>(
+      return await _assertUserpass(client, body).then<dynamic>(
         (UserpassBody userBody) => userBody.client
             .post(Uri.parse(url), body: getOrderbookToJson(userBody.body))
             .then(

--- a/lib/services/mm.dart
+++ b/lib/services/mm.dart
@@ -458,9 +458,8 @@ class ApiProvider {
       );
     } catch (e) {
       Log('ApiProvider.getOrderbook', 'Error on get orderbook: $e');
+      rethrow;
     }
-
-    return null;
   }
 
   Future<dynamic> getOrderbookDepth(


### PR DESCRIPTION
Changes:
- `getOrderbook` was not returning in the success case. So the result was always null, leading into a loading spinner animation on the orderbook page.
- Orderbook page was not showing any message at error on loading. Such as ZHTLC orderbook can't be loaded at the moment.
![image](https://github.com/KomodoPlatform/atomicdex-mobile/assets/6732486/2cfd9419-65a8-44b2-a555-71cf9cb24925)
